### PR TITLE
adding "OnBoardCredit" for ACID transaction demonstration

### DIFF
--- a/src/Org.Quickstart.API/Models/Profile.cs
+++ b/src/Org.Quickstart.API/Models/Profile.cs
@@ -7,6 +7,7 @@ namespace Org.Quickstart.API.Models
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Email { get; set; }
+        public decimal OnBoardCredit { get; set; }
 
         private string _password;
         public string Password {
@@ -19,5 +20,14 @@ namespace Org.Quickstart.API.Models
                 _password = BCrypt.Net.BCrypt.HashPassword(value);
             }
          }
+
+        public void TransferTo(Profile to, decimal amount)
+        {
+            // TODO: logic to make sure amount can't go negative
+            // and that amount isn't negative, etc
+
+            this.OnBoardCredit -= amount;
+            to.OnBoardCredit += amount;
+        }
     }
 }

--- a/src/Org.Quickstart.API/Models/ProfileCreateRequestCommand.cs
+++ b/src/Org.Quickstart.API/Models/ProfileCreateRequestCommand.cs
@@ -7,6 +7,7 @@ namespace Org.Quickstart.API.Models
         public string LastName { get; set; }
         public string Email { get; set; }
         public string Password { get; set; }
+        public decimal OnBoardCredit { get; set; }
 
         public Profile GetProfile()
         {
@@ -16,7 +17,8 @@ namespace Org.Quickstart.API.Models
                 FirstName = this.FirstName,
                 LastName = this.LastName,
                 Email = this.Email,
-                Password = this.Password
+                Password = this.Password,
+                OnBoardCredit = this.OnBoardCredit
             };
         }
     }

--- a/src/Org.Quickstart.API/Models/ProfileTransferCredit.cs
+++ b/src/Org.Quickstart.API/Models/ProfileTransferCredit.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Org.Quickstart.API.Models
+{
+    public class ProfileTransferCredit
+    {
+        public Guid Pfrom { get; set; }
+        public Guid Pto { get; set; }
+        public decimal Amount { get; set; }
+    }
+}

--- a/src/Org.Quickstart.API/Models/ProfileUpdateRequestCommand.cs
+++ b/src/Org.Quickstart.API/Models/ProfileUpdateRequestCommand.cs
@@ -8,6 +8,7 @@ namespace Org.Quickstart.API.Models
         public string LastName { get; set; }
         public string Email { get; set; }
         public string Password { get; set; }
+        public decimal OnBoardCredit { get; set; }
 
 	    public Profile GetProfile()
 	    {

--- a/src/Org.Quickstart.API/Org.Quickstart.API.csproj
+++ b/src/Org.Quickstart.API/Org.Quickstart.API.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Org.Quickstart.API' " />
   <ItemGroup>
+    <PackageReference Include="Couchbase.Transactions" Version="1.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />

--- a/src/Org.Quickstart.IntegrationTests/ControllerTests/ProfileTests.cs
+++ b/src/Org.Quickstart.IntegrationTests/ControllerTests/ProfileTests.cs
@@ -18,6 +18,7 @@ namespace Org.Quickstart.IntegrationTests.ControllerTests
         private readonly HttpClient _client;
 		private readonly string baseHostname = "/api/v1/profile";
 		private readonly string baseHostnameSearch = "/api/v1/profiles";
+		private readonly string baseHostnameTransfer = "/api/v1/transfer";
 
         public ProfileTests(CustomWebApplicationFactory<Startup> factory)
         {
@@ -140,13 +141,59 @@ namespace Org.Quickstart.IntegrationTests.ControllerTests
 			Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
 		}
 
-		private Profile GetProfile()
+        [Fact]
+        public async Task TransferOnBoardCreditAsync()
+        {
+            // amount to transfer
+            var transferAmount = 50.0M;
+
+            //create users
+            var fromProfile = GetProfile();
+            var fromUser = JsonConvert.SerializeObject(fromProfile);
+            var fromContent = new StringContent(fromUser, Encoding.UTF8, "application/json");
+            var fromResponse = await _client.PostAsync(baseHostname, fromContent);
+            var fromJson = await fromResponse.Content.ReadAsStringAsync();
+            fromProfile = JsonConvert.DeserializeObject<Profile>(fromJson);
+
+            var toProfile = GetProfile();
+            var toUser = JsonConvert.SerializeObject(toProfile);
+            var toContent = new StringContent(toUser, Encoding.UTF8, "application/json");
+            var toResponse = await _client.PostAsync(baseHostname, toContent);
+            var toJson = await toResponse.Content.ReadAsStringAsync();
+            toProfile = JsonConvert.DeserializeObject<Profile>(toJson);
+
+            // transfer funds
+            var transfer = new ProfileTransferCredit
+            {
+                Pfrom = fromProfile.Pid,
+                Pto = toProfile.Pid,
+                Amount = transferAmount
+            };
+            var transferJson = JsonConvert.SerializeObject(transfer);
+            var transferContent = new StringContent(transferJson, Encoding.UTF8, "application/json");
+            await _client.PostAsync(baseHostnameTransfer, transferContent);
+
+            // validate "from" user amount is down
+            var newFromResponse = await _client.GetAsync($"{baseHostname}/{fromProfile.Pid}");
+            var newFromJsonResult = await newFromResponse.Content.ReadAsStringAsync();
+            var newFromProfile = JsonConvert.DeserializeObject<Profile>(newFromJsonResult);
+            Assert.Equal(newFromProfile.OnBoardCredit, fromProfile.OnBoardCredit - transferAmount);
+
+            // validate "to" user amount is up
+            var newToResponse = await _client.GetAsync($"{baseHostname}/{toProfile.Pid}");
+            var newToJsonResult = await newToResponse.Content.ReadAsStringAsync();
+            var newToProfile = JsonConvert.DeserializeObject<Profile>(newToJsonResult);
+            Assert.Equal(newToProfile.OnBoardCredit, toProfile.OnBoardCredit + transferAmount);
+        }
+
+        private Profile GetProfile()
 	    {
 	        return new ProfileCreateRequestCommand(){
 		        FirstName = "John",
 		        LastName = "Doe",
 		        Email = "john.doe@couchbase.com",
-		        Password = "password"
+		        Password = "password",
+				OnBoardCredit = 500
 		    }.GetProfile(); 
 	    }
 
@@ -156,6 +203,7 @@ namespace Org.Quickstart.IntegrationTests.ControllerTests
 	        profile.LastName = "Smith";
 	        profile.Email = "Jane.Smith@couchbase.com";
 	        profile.Password = "password1";
-	    }
+            profile.OnBoardCredit = profile.OnBoardCredit;
+        }
     }
 }


### PR DESCRIPTION
I added "OnBoardCredit", like for a cruise ship, to the profile.

I added one endpoint to transfer credit from one user to another (e.g. from a parent profile to a child profile)

I also added an integration test to cover this endpoint.
